### PR TITLE
django-carton compatible with Django 1.9 (with fallback)

### DIFF
--- a/carton/module_loading.py
+++ b/carton/module_loading.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.utils.importlib import import_module
+from importlib import import_module
 
 
 def get_product_model():

--- a/carton/module_loading.py
+++ b/carton/module_loading.py
@@ -1,5 +1,10 @@
+import django
 from django.conf import settings
-from importlib import import_module
+
+if django.VERSION[:2] == (1, 9):
+    from importlib import import_module
+else:
+    from django.utils.importlib import import_module
 
 
 def get_product_model():


### PR DESCRIPTION
use importlibs instead of django.utils.importlib if using django > 1.9