### PR TITLE
added explanation for accessing product ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Template:
         {{ product.name }}
     {% endfor %}
 
+Within the template you can access the product id with {{product.id}}. 
+
 Settings:
 
     CART_PRODUCT_MODEL = 'products.models.Product'


### PR DESCRIPTION
I struggled with this; a simple addition to the docs on accessing the product id in the template would have saved me a lot of time.